### PR TITLE
Get name instead of path at VLC

### DIFF
--- a/app-rules.yaml
+++ b/app-rules.yaml
@@ -11,7 +11,7 @@ MPlayer OSX Extended:
 VLC:
  identifier: org.videolan.vlc
  osascript: >
-  tell application "VLC" to path of current item
+  tell application "VLC" to name of current item
 QuickTime Player:
  identifier: com.apple.QuickTimePlayerX
 mpv:


### PR DESCRIPTION
The current AppleScript method for VLC (`path of current item`) ignores the video title when playing stream playlists (`.pls` files) and gets the stream url path instead. Using `name of current item`, osascript gets the video meta title and if the file or playlist doesn't have one, it gets the video file name instead. 

The `name` property will not return the file absolute path at the fallback, only the file name, but this shouldn't be a problem if the app only parses the file name.
